### PR TITLE
Handle RADIO health messages

### DIFF
--- a/swarm_mission_uploader_gui_sik_pro_map_v2/src/gui_uploader.py
+++ b/swarm_mission_uploader_gui_sik_pro_map_v2/src/gui_uploader.py
@@ -117,7 +117,7 @@ class SwarmGUI:
         top=ttk.Frame(parent,padding=8); top.pack(fill='x')
         ttk.Button(top,text='Start Monitoring',command=self.health_start).pack(side='left',padx=5)
         ttk.Button(top,text='Stop Monitoring',command=self.health_stop).pack(side='left',padx=5)
-        ttk.Label(top,text='(Monitors RADIO_STATUS from each configured port)').pack(side='left',padx=12)
+        ttk.Label(top,text='(Monitors RADIO_STATUS/RADIO from each configured port)').pack(side='left',padx=12)
 
         self.health_tree=ttk.Treeview(parent,columns=('port','rssi','remrssi','noise','rxerr','updated'),show='headings',height=14)
         for c,t,w in [('port','Port',340),('rssi','RSSI',100),('remrssi','Remote RSSI',120),('noise','Noise',100),('rxerr','RX Errors',100),('updated','Updated',160)]:
@@ -147,7 +147,7 @@ class SwarmGUI:
             while self._health_alive:
                 msg=m.recv_match(blocking=False)
                 if not msg: time.sleep(0.05); continue
-                if msg.get_type()=='RADIO_STATUS':
+                if msg.get_type() in ('RADIO_STATUS', 'RADIO'):
                     vals=(getattr(msg,'rssi',None),getattr(msg,'remrssi',None),getattr(msg,'noise',None),getattr(msg,'rxerrors',None))
                     self._health_update_row(ep, *vals)
             break


### PR DESCRIPTION
## Summary
- update the radio health tab text to mention both RADIO_STATUS and RADIO messages
- allow the health monitor worker to process RADIO MAVLink messages in addition to RADIO_STATUS

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8dea56e9c832b87b4abff2028c18a