### PR TITLE
Add satellite imagery background to live map

### DIFF
--- a/swarm_mission_uploader_gui_sik_pro_map_v2/requirements.txt
+++ b/swarm_mission_uploader_gui_sik_pro_map_v2/requirements.txt
@@ -1,3 +1,4 @@
 pymavlink>=2.4.39
 pyserial>=3.5
 matplotlib>=3.7.0
+Pillow>=9.0.0


### PR DESCRIPTION
## Summary
- render the live map on top of satellite imagery tiles and cache downloads with graceful fallbacks
- switch plotting to Web Mercator coordinates with degree tick formatting and enhanced vehicle markers
- add the Pillow dependency to load map tiles for the background overlay

## Testing
- python -m compileall swarm_mission_uploader_gui_sik_pro_map_v2/src

------
https://chatgpt.com/codex/tasks/task_e_68c8ef2d51b8832b8155095122d59d50